### PR TITLE
[FIX] Enable session_redis to work with Sentry

### DIFF
--- a/session_redis/__manifest__.py
+++ b/session_redis/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sessions in Redis",
     "summary": "Store web sessions in Redis",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Extra Tools",

--- a/session_redis/http.py
+++ b/session_redis/http.py
@@ -1,6 +1,6 @@
 # Copyright 2016-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
-
+import glob
 import logging
 import os
 
@@ -61,12 +61,13 @@ def session_store(self):
 
 
 def purge_fs_sessions(path):
-    for fname in os.listdir(path):
-        path = os.path.join(path, fname)
+    # Same logic as odoo.http.FilesystemSessionStore.vacuum
+    for fname in glob.iglob(os.path.join(path, '*', '*')):
+        session_file = os.path.join(path, fname)
         try:
-            os.unlink(path)
+            os.unlink(session_file)
         except OSError:
-            _logger.warning("OS Error during purge of redis sessions.")
+            _logger.exception(f"OS Error during purge of old sessions: {session_file}")
 
 
 if is_true(os.environ.get("ODOO_SESSION_REDIS")):


### PR DESCRIPTION
When the sentry module is loaded, it overrides odoo.http.Application with a middleware object that wraps the original, but does not proxy it. Thus the session_store property that session_redis monkeypatches is no longer there.

This fix intends to avoid that, without having very specific knowledge about the sentry module baked in.

The solution seems to work, but has the risk that if the Application class is fully replaced (i.e. if it is not even wrapped), then this new method may lead to this module simply not working, and the reasons for it may be difficult to debug. But the only way around that would be to explicitly check the wrapper object contains the expected class, and that is basically the same as depending on the sentry module.